### PR TITLE
Feature/docs get started

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install @prototyp/react-language-switcher
 The gist of using this plugin consists of two components. A Language provider that provides the language context and the ways of using it, and the Language Switcher component that allows you to style and use this logic.
 
 ```jsx
-<LanguageProvider config={{ languageList: ['en', 'de', 'fr'] }}>
+<LanguageProvider config={{ language: 'en', languageList: ['en', 'de', 'fr'] }}>
     <LanguageSwitcher />
 </LanguageProvider>
 ```

--- a/stories/components/language-context.stories.mdx
+++ b/stories/components/language-context.stories.mdx
@@ -84,7 +84,7 @@ You can also use the LanguageContext.Consumer component if you prefer that way.
         description: 'string[]',
         type: PropTypes.arrayOf(PropTypes.string),
         required: true,
-        defaultValue: { summary: '[]' },
+        defaultValue: { summary: "['en']" },
       },
       {
         name: 'setLanguage',

--- a/stories/documentation/getStarted.stories.mdx
+++ b/stories/documentation/getStarted.stories.mdx
@@ -1,0 +1,44 @@
+import { Meta, Preview } from '@storybook/addon-docs/blocks';
+
+<Meta title="Documentation|Get started" />
+
+# Get started
+
+The core of `react-language-switcher` library leverages the [React Context API][1] by providing the set of two main components:
+
+- a language Provider that provides the language context and the ways of using it
+- a language Switcher component that allows you to style and use this logic
+
+### Basic usage
+
+Wrapping your application with a language Provider component exposes the language context to its children. Using a language
+Switcher component anywhere inside the child component tree will consume the language context and provide you with an unstyled
+unordered list of provided languages. Rendered list items contain unstyled buttons for changing the application language.
+
+```tsx
+import {
+  LanguageProvider,
+  LanguageSwitcher,
+} from '@prototyp/react-language-switcher';
+
+const App = () => (
+  <LanguageProvider>
+    <LanguageSwitcher />
+  </LanguageProvider>
+);
+```
+
+By default, the `LanguageProvider` component will use English as a selected language and the `LanguageSwitcher` component will render
+a list with only the English language option.
+
+Optionally, the `LanguageProvider` component takes a config object as a prop, which defines the selected language for the app
+and a list of all languages that will be used inside the app.
+
+```tsx
+<LanguageProvider config={{ language: 'en', languageList: ['en', 'de', 'fr'] }}>
+  <LanguageSwitcher />
+</LanguageProvider>
+```
+
+[1]: https://reactjs.org/docs/context.html
+


### PR DESCRIPTION
This PR adds "Get started" story to documentation:
![image](https://user-images.githubusercontent.com/20628918/75635122-d7a0e000-5c13-11ea-87a1-ff77febbff9a.png)



It fixes LanguageContextProps in README because language is a mandatory prop:
<img width="930" alt="Screenshot 2020-03-01 at 21 11 27" src="https://user-images.githubusercontent.com/20628918/75635174-32d2d280-5c14-11ea-9589-883e04f71892.png">


It adds default `languageList` inside story to ['en'] because it's initialized that way here:
```tsx
export const LanguageContext = createContext<LanguageContextProps>({
  language: DEFAULT_ISO_LANGUAGE,
  languageList: [DEFAULT_ISO_LANGUAGE],
});
```